### PR TITLE
Three refactorings.

### DIFF
--- a/weidu_library/blocks.tpa
+++ b/weidu_library/blocks.tpa
@@ -43,7 +43,7 @@ BEGIN
             LPF encode_opcode_type STR_VAR value = "%opcode%" RET opcode = return END
 
             PATCH_IF NOT ("%parameter1%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_resource_ref STR_VAR value = "%parameter1%" RET parameter1 = return END
+                LPF encode_table_ref STR_VAR value = "%parameter1%" RET parameter1 = return END
                 PATCH_IF NOT (IS_AN_INT parameter1) BEGIN
                     PATCH_FAIL "patch_block_with_table: 'parameter1' value of row '%i%' is not an encoded integer."
                 END
@@ -52,7 +52,7 @@ BEGIN
             END
 
             PATCH_IF NOT ("%parameter2%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_resource_ref STR_VAR value = "%parameter2%" RET parameter2 = return END
+                LPF encode_table_ref STR_VAR value = "%parameter2%" RET parameter2 = return END
                 PATCH_IF NOT (IS_AN_INT parameter1) BEGIN
                     PATCH_FAIL "patch_block_with_table: 'parameter2' value of row '%i%' is not an encoded integer."
                 END
@@ -61,7 +61,7 @@ BEGIN
             END
             
             PATCH_IF NOT ("%resource%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_resource_ref STR_VAR value = "%resource%" RET resource = return END
+                LPF encode_table_ref STR_VAR value = "%resource%" RET resource = return END
             END ELSE BEGIN
                 TEXT_SPRINT resource ""
             END
@@ -129,7 +129,7 @@ DEFINE_PATCH_FUNCTION append_item_block_with_table STR_VAR table = "" BEGIN
             LPF encode_opcode_type STR_VAR value = "%opcode%" RET opcode = return END
 
             PATCH_IF NOT ("%parameter1%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_resource_ref STR_VAR value = "%parameter1%" RET parameter1 = return END
+                LPF encode_table_ref STR_VAR value = "%parameter1%" RET parameter1 = return END
                 PATCH_IF NOT (IS_AN_INT parameter1) BEGIN
                     PATCH_FAIL "append_item_block_with_table: 'parameter1' value of row '%i%' is not an encoded integer."
                 END
@@ -138,7 +138,7 @@ DEFINE_PATCH_FUNCTION append_item_block_with_table STR_VAR table = "" BEGIN
             END
 
             PATCH_IF NOT ("%parameter2%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_resource_ref STR_VAR value = "%parameter2%" RET parameter2 = return END
+                LPF encode_table_ref STR_VAR value = "%parameter2%" RET parameter2 = return END
                 PATCH_IF NOT (IS_AN_INT parameter1) BEGIN
                     PATCH_FAIL "append_item_block_with_table: 'parameter2' value of row '%i%' is not an encoded integer."
                 END
@@ -147,7 +147,7 @@ DEFINE_PATCH_FUNCTION append_item_block_with_table STR_VAR table = "" BEGIN
             END
             
             PATCH_IF NOT ("%resource%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_resource_ref STR_VAR value = "%resource%" RET resource = return END
+                LPF encode_table_ref STR_VAR value = "%resource%" RET resource = return END
             END ELSE BEGIN
                 TEXT_SPRINT resource ""
             END
@@ -210,7 +210,7 @@ BEGIN
             LPF encode_opcode_type STR_VAR value = "%opcode%" RET opcode = return END
 
             PATCH_IF NOT ("%parameter1%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_resource_ref STR_VAR value = "%parameter1%" RET parameter1 = return END
+                LPF encode_table_ref STR_VAR value = "%parameter1%" RET parameter1 = return END
                 PATCH_IF NOT (IS_AN_INT parameter1) BEGIN
                     PATCH_FAIL "append_spell_block_with_table: 'parameter1' value of row '%i%' is not an encoded integer."
                 END
@@ -219,7 +219,7 @@ BEGIN
             END
 
             PATCH_IF NOT ("%parameter2%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_resource_ref STR_VAR value = "%parameter2%" RET parameter2 = return END
+                LPF encode_table_ref STR_VAR value = "%parameter2%" RET parameter2 = return END
                 PATCH_IF NOT (IS_AN_INT parameter1) BEGIN
                     PATCH_FAIL "append_spell_block_with_table: 'parameter2' value of row '%i%' is not an encoded integer."
                 END
@@ -228,7 +228,7 @@ BEGIN
             END
             
             PATCH_IF NOT ("%resource%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_resource_ref STR_VAR value = "%resource%" RET resource = return END
+                LPF encode_table_ref STR_VAR value = "%resource%" RET resource = return END
             END ELSE BEGIN
                 TEXT_SPRINT resource ""
             END

--- a/weidu_library/blocks.tpa
+++ b/weidu_library/blocks.tpa
@@ -43,7 +43,7 @@ BEGIN
             LPF encode_opcode_type STR_VAR value = "%opcode%" RET opcode = return END
 
             PATCH_IF NOT ("%parameter1%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_table_ref STR_VAR value = "%parameter1%" RET parameter1 = return END
+                LPF encode_table_reference STR_VAR value = "%parameter1%" RET parameter1 = return END
                 PATCH_IF NOT (IS_AN_INT parameter1) BEGIN
                     PATCH_FAIL "patch_block_with_table: 'parameter1' value of row '%i%' is not an encoded integer."
                 END
@@ -52,7 +52,7 @@ BEGIN
             END
 
             PATCH_IF NOT ("%parameter2%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_table_ref STR_VAR value = "%parameter2%" RET parameter2 = return END
+                LPF encode_table_reference STR_VAR value = "%parameter2%" RET parameter2 = return END
                 PATCH_IF NOT (IS_AN_INT parameter1) BEGIN
                     PATCH_FAIL "patch_block_with_table: 'parameter2' value of row '%i%' is not an encoded integer."
                 END
@@ -61,7 +61,7 @@ BEGIN
             END
             
             PATCH_IF NOT ("%resource%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_table_ref STR_VAR value = "%resource%" RET resource = return END
+                LPF encode_table_reference STR_VAR value = "%resource%" RET resource = return END
             END ELSE BEGIN
                 TEXT_SPRINT resource ""
             END
@@ -129,7 +129,7 @@ DEFINE_PATCH_FUNCTION append_item_block_with_table STR_VAR table = "" BEGIN
             LPF encode_opcode_type STR_VAR value = "%opcode%" RET opcode = return END
 
             PATCH_IF NOT ("%parameter1%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_table_ref STR_VAR value = "%parameter1%" RET parameter1 = return END
+                LPF encode_table_reference STR_VAR value = "%parameter1%" RET parameter1 = return END
                 PATCH_IF NOT (IS_AN_INT parameter1) BEGIN
                     PATCH_FAIL "append_item_block_with_table: 'parameter1' value of row '%i%' is not an encoded integer."
                 END
@@ -138,7 +138,7 @@ DEFINE_PATCH_FUNCTION append_item_block_with_table STR_VAR table = "" BEGIN
             END
 
             PATCH_IF NOT ("%parameter2%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_table_ref STR_VAR value = "%parameter2%" RET parameter2 = return END
+                LPF encode_table_reference STR_VAR value = "%parameter2%" RET parameter2 = return END
                 PATCH_IF NOT (IS_AN_INT parameter1) BEGIN
                     PATCH_FAIL "append_item_block_with_table: 'parameter2' value of row '%i%' is not an encoded integer."
                 END
@@ -147,7 +147,7 @@ DEFINE_PATCH_FUNCTION append_item_block_with_table STR_VAR table = "" BEGIN
             END
             
             PATCH_IF NOT ("%resource%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_table_ref STR_VAR value = "%resource%" RET resource = return END
+                LPF encode_table_reference STR_VAR value = "%resource%" RET resource = return END
             END ELSE BEGIN
                 TEXT_SPRINT resource ""
             END
@@ -210,7 +210,7 @@ BEGIN
             LPF encode_opcode_type STR_VAR value = "%opcode%" RET opcode = return END
 
             PATCH_IF NOT ("%parameter1%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_table_ref STR_VAR value = "%parameter1%" RET parameter1 = return END
+                LPF encode_table_reference STR_VAR value = "%parameter1%" RET parameter1 = return END
                 PATCH_IF NOT (IS_AN_INT parameter1) BEGIN
                     PATCH_FAIL "append_spell_block_with_table: 'parameter1' value of row '%i%' is not an encoded integer."
                 END
@@ -219,7 +219,7 @@ BEGIN
             END
 
             PATCH_IF NOT ("%parameter2%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_table_ref STR_VAR value = "%parameter2%" RET parameter2 = return END
+                LPF encode_table_reference STR_VAR value = "%parameter2%" RET parameter2 = return END
                 PATCH_IF NOT (IS_AN_INT parameter1) BEGIN
                     PATCH_FAIL "append_spell_block_with_table: 'parameter2' value of row '%i%' is not an encoded integer."
                 END
@@ -228,7 +228,7 @@ BEGIN
             END
             
             PATCH_IF NOT ("%resource%" STRING_EQUAL_CASE "*") BEGIN
-                LPF encode_table_ref STR_VAR value = "%resource%" RET resource = return END
+                LPF encode_table_reference STR_VAR value = "%resource%" RET resource = return END
             END ELSE BEGIN
                 TEXT_SPRINT resource ""
             END

--- a/weidu_library/docs/libraries/references.md
+++ b/weidu_library/docs/libraries/references.md
@@ -1,20 +1,20 @@
 # References.
 
-Library to aid in resource name management, by allowing to use more complex resource references than the standard 8-character strings.
+Resource installation is done via tables, but these have a format that implies certain restrinctions in the values (for example, no spaces). This library introduces a tiny dsl to allow more complex expressions.
 
-A resource reference, as used in several .2da tables used by installer libraries, has the following regexp format:
+A *table reference*, as used in several .2da tables used by installer libraries, has the following regexp format:
 
 ```regexp
-^#([a-zA-Z0-9][a-zA-Z0-9_-]*):(.+)$
+^#([a-zA-Z0-9][a-zA-Z0-9_-]*):(.*)$
 ```
 
-The first group, an alpha-numeric identifier, uniquely identifies the function that is to be called, while the second group, is the argument to pass to it. The string it returns is the resource's name. In short, and denoting the first group by `function` and the second by `value`, this is inline notation for the call
+The first group, an alpha-numeric identifier, uniquely identifies the function that is to be called, while the second group, is the argument to pass to it. The string it returns can be anything, but is usually a string or number that has passed some validation checks. In short, and denoting the first group by `function` and the second by `value`, this is inline notation for the call
 
 ```weidu
 LAF "%function%" STR_VAR value = "%value% RET resource
 ```
 
-Each `function` is then free to parse `value` as necessary.
+Each `function` is free to parse `value` as necessary.
 
 file(s):
 
@@ -25,26 +25,29 @@ file(s):
 note(s):
 * All functions in this section have patch and action variants.
 
-`get_resource_ref STR_VAR ref RET resource`
+`get_table_ref STR_VAR ref RET resource`
 
-This is the main entry point of the library, and parses a `ref` into a function call. In details: parses the string `ref` against the regexp `^#([a-zA-Z0-9][a-zA-Z0-9_-]*):(.+)$` and grabs the extracted function's name and value. If `value` does not match the regexp, the function FAIL's. If it matches, return whatever the return value of the function call:
+This is the main entry point of the library, and parses a `ref` into a function call. In details: parses the string `ref` against the regexp `^#([a-zA-Z0-9][a-zA-Z0-9_-]*):(.*)$` and grabs the extracted function's name and the argument value. If `ref` does not match the regexp, the function FAIL's. If it matches, lookup the name in a table of `name => function` pairs and return whatever the function call returns:
 
 ```weidu
 LPF "%function%" STR_VAR value = "%value%" RET return
 ```
 
-Note the signature of the called function: one argument named `value` and the return value named `return` -- the signature of an encoder. The available formats are detailed in the formats section.
+Note the signature of the called function: one argument named `value` and the return value named `return` -- the signature of an *encoder*. The available formats are detailed in the formats section.
 
-note(s):
-* even though the return value is named `resource`, this function can return values other than resource (references).
+`encode_table_ref STR_VAR value RET return`
+
+Encoder version of `get_table_ref`.
 
 # B. Formats.
 
-The following functions are the available encoders. There is usually no need to call them directly, rather call them indirectly with a resource ref via `get_resource_ref`.
+The following functions are the available encoders. There is usually no need to call them directly, rather call them indirectly with a resource ref via `get_table_ref`.
 
-`encode_ref_literal STR_VAR value RET return`
+## B. 1. String formats.
 
-Treats `value` as a literal resource name and returns it unchanged, except for lower-casing. Format is:
+`encode_resource_literal STR_VAR value RET return`
+
+Treats `value` as a literal and returns it unchanged, except for upper-casing. Format is:
 
 ```
 #lit:<resource reference>
@@ -53,6 +56,33 @@ Treats `value` as a literal resource name and returns it unchanged, except for l
 note(s):
 * it also checks the length, that is, if length of the resource reference is strictly larger than 8 the function FAIL's.
 
+`encode_empty_string STR_VAR value RET return`
+
+Returns the empty string. Format is:
+
+```
+#nul:
+```
+
+Note that value is the empty string; if anything follows the colon, the function FAIL's.
+
+## B. 2. Numeric formats.
+
+`encode_int_literal STR_VAR value RET return`
+
+Treats `value` as an integer literal and returns it. Format is:
+
+```
+#int:<numeric literal>
+```
+
+Both decimal and hex literals are accepted.
+
+note(s):
+* this is useful mainly if the values in a given column can be either numbers or some other kind of object, and this provides a way to disambiguate. If all values must be integers (as checked by the table processing code) there is little point in using this format. One use case is the [Blocks library](./blocks.md) where the column values can have various interpretations depending on the value of another column (e.g. this is a (very) primitive form of dependent typing).
+
+## B. 3. Spell-related formats.
+
 `encode_spell_res STR_VAR value RET return`
 
 Treats `value` as a symbolic spell reference in `spell.ids` and returns the corresponding resource reference. Function FAIL's if `value` not present in `spell.ids`. Format is:
@@ -60,20 +90,6 @@ Treats `value` as a symbolic spell reference in `spell.ids` and returns the corr
 ```
 #spl:<spell symbolic reference>
 ```
-
-note(s):
-* Function from [Encoders](./internal/encoders.md).
-
-`encode_missile_res STR_VAR value RET return`
-
-Treats `value` as a symbolic projectile reference in `missile.ids` and returns the corresponding resource reference. Function FAIL's if `value` not present in `spell.ids`. Format is:
-
-```
-#lbl:<missile reference>
-```
-
-note(s):
-* Function from [Encoders](./internal/encoders.md).
 
 `encode_spell_suffix STR_VAR value RET return`
 
@@ -91,6 +107,21 @@ Returns the symbolic spell reference suffixed with a character and the first two
 #afx:<two alphanumeric characters>:<one alphanumeric character>:<spell symbolic reference>
 ```
 
+## B. 4. Projectile-related formats.
+
+`encode_missile_res STR_VAR value RET return`
+
+Treats `value` as a symbolic projectile reference in `missile.ids` and returns the corresponding resource reference. Function FAIL's if `value` not present in `spell.ids`. Format is:
+
+```
+#lbl:<missile reference>
+```
+
+note(s):
+* Function from [Encoders](./internal/encoders.md).
+
+## B. 5. Opcode-related formats.
+
 `encode_opcode_type STR_VAR value RET return`
 
 Returns the numeric id of an opcode type. Function FAIL's if `value` not present in [Opcodes table](../../resources/2da/opcodes/types.2da). Format is:
@@ -99,11 +130,19 @@ Returns the numeric id of an opcode type. Function FAIL's if `value` not present
 #opc:<opcode type>
 ```
 
-# C. Encoders.
+## B. 6. Sectype-related formats.
 
-`encode_resource_ref STR_VAR value RET return`
+`encode_spell_sectype STR_VAR value RET return`
 
-Encoder version of `get_resource_ref`.
+Returns the numeric id of a sectype. Function FAIL's if `value` is not a valid sectype. Associated format is:
+
+```
+#sct:<sectype>
+```
+
+# C. Other resource encoders.
+
+The next set of encoders have no format associated and are mainly used as value sanitizers.
 
 `encode_bam_ref STR_VAR value RET return`
 
@@ -111,4 +150,4 @@ Encoder version of `get_resource_ref`.
 
 `encode_script_ref STR_VAR value RET return`
 
-These encoders parse a resource reference for a resopurce of the apprpriate type, do an extra existence check and return the value.
+These encoders parse a resource reference for a resource of the apprpriate type, do an extra existence check and return the value.

--- a/weidu_library/docs/libraries/references.md
+++ b/weidu_library/docs/libraries/references.md
@@ -25,7 +25,7 @@ file(s):
 note(s):
 * All functions in this section have patch and action variants.
 
-`expand_table_reference STR_VAR ref RET resource`
+`encode_table_reference STR_VAR value RET return`
 
 This is the main entry point of the library, and parses a `ref` into a function call. In details: parses the string `ref` against the regexp `^#([a-zA-Z0-9][a-zA-Z0-9_-]*):(.*)$` and grabs the extracted function's name and the argument value. If `ref` does not match the regexp, the function FAIL's. If it matches, lookup the name in a table of `name => function` pairs and return whatever the function call returns:
 
@@ -34,10 +34,6 @@ LPF "%function%" STR_VAR value = "%value%" RET return
 ```
 
 Note the signature of the called function: one argument named `value` and the return value named `return` -- the signature of an *encoder*. The available formats are detailed in the formats section.
-
-`encode_table_reference STR_VAR value RET return`
-
-Encoder version of `expand_table_reference`.
 
 # B. Formats.
 

--- a/weidu_library/docs/libraries/references.md
+++ b/weidu_library/docs/libraries/references.md
@@ -25,7 +25,7 @@ file(s):
 note(s):
 * All functions in this section have patch and action variants.
 
-`get_table_ref STR_VAR ref RET resource`
+`expand_table_reference STR_VAR ref RET resource`
 
 This is the main entry point of the library, and parses a `ref` into a function call. In details: parses the string `ref` against the regexp `^#([a-zA-Z0-9][a-zA-Z0-9_-]*):(.*)$` and grabs the extracted function's name and the argument value. If `ref` does not match the regexp, the function FAIL's. If it matches, lookup the name in a table of `name => function` pairs and return whatever the function call returns:
 
@@ -35,13 +35,13 @@ LPF "%function%" STR_VAR value = "%value%" RET return
 
 Note the signature of the called function: one argument named `value` and the return value named `return` -- the signature of an *encoder*. The available formats are detailed in the formats section.
 
-`encode_table_ref STR_VAR value RET return`
+`encode_table_reference STR_VAR value RET return`
 
-Encoder version of `get_table_ref`.
+Encoder version of `expand_table_reference`.
 
 # B. Formats.
 
-The following functions are the available encoders. There is usually no need to call them directly, rather call them indirectly with a resource ref via `get_table_ref`.
+The following functions are the available encoders. There is usually no need to call them directly, rather call them indirectly with a resource ref via `encode_table_reference`.
 
 ## B. 1. String formats.
 

--- a/weidu_library/installers.tpa
+++ b/weidu_library/installers.tpa
@@ -176,9 +176,9 @@ BEGIN
                 ACTION_IF NOT (install = 0) BEGIN
                     //Compute destination.
                     ACTION_IF NOT ("%destination%" STRING_EQUAL_CASE "*") BEGIN
-                        LAF expand_table_reference STR_VAR
-                            ref = "%destination%"
-                        RET destination = resource END
+                        LAF encode_table_reference STR_VAR
+                            value = "%destination%"
+                        RET destination = return END
                     END
 
                     //Existence debug checks.
@@ -249,9 +249,9 @@ DEFINE_DIMORPHIC_FUNCTION get_table_references STR_VAR tables = "" dir = "*" RET
                 READ_2DA_ENTRY_FORMER "table#rows" i (cols - 1) ref
 
                 //Compute final destination.
-                LPF expand_table_reference STR_VAR
-                    ref = "%ref%"
-                RET destination = resource END
+                LPF encode_table_reference STR_VAR
+                    value = "%ref%"
+                RET destination = return END
                 
                 TEXT_SPRINT $"references"("%resource%") "%destination%"
             END

--- a/weidu_library/installers.tpa
+++ b/weidu_library/installers.tpa
@@ -176,7 +176,7 @@ BEGIN
                 ACTION_IF NOT (install = 0) BEGIN
                     //Compute destination.
                     ACTION_IF NOT ("%destination%" STRING_EQUAL_CASE "*") BEGIN
-                        LAF get_resource_ref STR_VAR
+                        LAF get_table_ref STR_VAR
                             ref = "%destination%"
                         RET destination = resource END
                     END
@@ -249,7 +249,7 @@ DEFINE_DIMORPHIC_FUNCTION get_table_references STR_VAR tables = "" dir = "*" RET
                 READ_2DA_ENTRY_FORMER "table#rows" i (cols - 1) ref
 
                 //Compute final destination.
-                LPF get_resource_ref STR_VAR
+                LPF get_table_ref STR_VAR
                     ref = "%ref%"
                 RET destination = resource END
                 

--- a/weidu_library/installers.tpa
+++ b/weidu_library/installers.tpa
@@ -188,15 +188,19 @@ BEGIN
                             FAIL "install_resources: '%override%' is not an integer."
                         END
 
-                        ACTION_IF NOT ((0 <= override) AND (override <= 2)) BEGIN
-                            FAIL "install_resources: '%override%' not an integer in the [0, 2] range."
+                        ACTION_IF NOT ((0 <= override) AND (override <= 3)) BEGIN
+                            FAIL "install_resources: '%override%' not an integer in the [0, 3] range."
                         END
 
                         ACTION_IF (0 = override) AND (FILE_EXISTS_IN_GAME "%destination%.%ext%") BEGIN
                             FAIL "install_resources: destination '%destination%.%ext%' for '%resource%' already exists in game."
                         END
 
-                        ACTION_IF (2 = override) AND (NOT (FILE_EXISTS_IN_GAME "%destination%.%ext%")) BEGIN
+                        ACTION_IF (2 = override) AND (FILE_EXISTS_IN_GAME "%destination%.%ext%") BEGIN
+                            WARN "Warning:install_resources: destination '%destination%.%ext%' for '%resource%' already exists in game."
+                        END
+
+                        ACTION_IF (3 = override) AND (NOT (FILE_EXISTS_IN_GAME "%destination%.%ext%")) BEGIN
                             FAIL "install_resources: destination '%destination%.%ext%' for '%resource%' declared to exist but does not."
                         END
                     END

--- a/weidu_library/installers.tpa
+++ b/weidu_library/installers.tpa
@@ -176,7 +176,7 @@ BEGIN
                 ACTION_IF NOT (install = 0) BEGIN
                     //Compute destination.
                     ACTION_IF NOT ("%destination%" STRING_EQUAL_CASE "*") BEGIN
-                        LAF get_table_ref STR_VAR
+                        LAF expand_table_reference STR_VAR
                             ref = "%destination%"
                         RET destination = resource END
                     END
@@ -249,7 +249,7 @@ DEFINE_DIMORPHIC_FUNCTION get_table_references STR_VAR tables = "" dir = "*" RET
                 READ_2DA_ENTRY_FORMER "table#rows" i (cols - 1) ref
 
                 //Compute final destination.
-                LPF get_table_ref STR_VAR
+                LPF expand_table_reference STR_VAR
                     ref = "%ref%"
                 RET destination = resource END
                 

--- a/weidu_library/internal/installers/animations.tpa
+++ b/weidu_library/internal/installers/animations.tpa
@@ -8,7 +8,7 @@ INCLUDE "%WEIDU_LIBRARY_DIR%/vvcs.tpa"
 DEFINE_PATCH_FUNCTION write_projectile_fields STR_VAR fields = "" BEGIN
     PHP_EACH "%fields%" AS field => value BEGIN
         PATCH_IF ("%field%" STRING_EQUAL_CASE "animation") AND (NOT ("%value%" STRING_EQUAL_CASE "*")) BEGIN
-            LPF get_table_ref STR_VAR
+            LPF expand_table_reference STR_VAR
                 ref = "%value%"
             RET res = resource END
 

--- a/weidu_library/internal/installers/animations.tpa
+++ b/weidu_library/internal/installers/animations.tpa
@@ -8,9 +8,9 @@ INCLUDE "%WEIDU_LIBRARY_DIR%/vvcs.tpa"
 DEFINE_PATCH_FUNCTION write_projectile_fields STR_VAR fields = "" BEGIN
     PHP_EACH "%fields%" AS field => value BEGIN
         PATCH_IF ("%field%" STRING_EQUAL_CASE "animation") AND (NOT ("%value%" STRING_EQUAL_CASE "*")) BEGIN
-            LPF expand_table_reference STR_VAR
-                ref = "%value%"
-            RET res = resource END
+            LPF encode_table_reference STR_VAR
+                value = "%value%"
+            RET res = return END
 
             PATCH_IF NOT (FILE_EXISTS_IN_GAME "%res%.bam") BEGIN
                 PATCH_FAIL "write_projectile_fields: resource '%res%.bam' for animation field does not exist in game."

--- a/weidu_library/internal/installers/animations.tpa
+++ b/weidu_library/internal/installers/animations.tpa
@@ -8,7 +8,7 @@ INCLUDE "%WEIDU_LIBRARY_DIR%/vvcs.tpa"
 DEFINE_PATCH_FUNCTION write_projectile_fields STR_VAR fields = "" BEGIN
     PHP_EACH "%fields%" AS field => value BEGIN
         PATCH_IF ("%field%" STRING_EQUAL_CASE "animation") AND (NOT ("%value%" STRING_EQUAL_CASE "*")) BEGIN
-            LPF get_resource_ref STR_VAR
+            LPF get_table_ref STR_VAR
                 ref = "%value%"
             RET res = resource END
 

--- a/weidu_library/internal/installers/create_effects.tpa
+++ b/weidu_library/internal/installers/create_effects.tpa
@@ -33,9 +33,9 @@ BEGIN
             //Currently can only insert saves as integers.
             "savingthrow"   => "encode_positive"
             "savebonus"     => "encode_opcode_save_bonus"
-            "resource"      => "encode_resource_ref"
-            "resource2"     => "encode_resource_ref"
-            "resource3"     => "encode_resource_ref"
+            "resource"      => "encode_table_ref"
+            "resource2"     => "encode_table_ref"
+            "resource3"     => "encode_table_ref"
             "special"       => "encode_identity"
             "projectile"    => "encode_projectile_ref"
             "school"        => "encode_spell_school"

--- a/weidu_library/internal/installers/create_effects.tpa
+++ b/weidu_library/internal/installers/create_effects.tpa
@@ -33,9 +33,9 @@ BEGIN
             //Currently can only insert saves as integers.
             "savingthrow"   => "encode_positive"
             "savebonus"     => "encode_opcode_save_bonus"
-            "resource"      => "encode_table_ref"
-            "resource2"     => "encode_table_ref"
-            "resource3"     => "encode_table_ref"
+            "resource"      => "encode_table_reference"
+            "resource2"     => "encode_table_reference"
+            "resource3"     => "encode_table_reference"
             "special"       => "encode_identity"
             "projectile"    => "encode_projectile_ref"
             "school"        => "encode_spell_school"

--- a/weidu_library/internal/installers/items.tpa
+++ b/weidu_library/internal/installers/items.tpa
@@ -148,9 +148,9 @@ DEFINE_ACTION_FUNCTION item_post_processing STR_VAR table = "" BEGIN
 
                     PATCH_IF NOT ("%exclusion%" STRING_EQUAL_CASE "*") BEGIN
                         //Compute destination.
-                        LPF expand_table_reference STR_VAR
-                            ref = "%destination%"
-                        RET destination = resource END
+                        LPF encode_table_reference STR_VAR
+                            value = "%destination%"
+                        RET destination = return END
 
                         //Write out.
                         LPF set_item_exclusion INT_VAR
@@ -186,9 +186,9 @@ DEFINE_ACTION_FUNCTION item_post_processing STR_VAR table = "" BEGIN
                     TEXT_SPRINT ability3 $"row"("ability3")
 
                     //Compute destination.
-                    LPF expand_table_reference STR_VAR
-                        ref = "%destination%"
-                    RET destination = resource END
+                    LPF encode_table_reference STR_VAR
+                        value = "%destination%"
+                    RET destination = return END
 
                     //Sanitize
                     PATCH_IF NOT (IS_AN_INT ability1) BEGIN

--- a/weidu_library/internal/installers/items.tpa
+++ b/weidu_library/internal/installers/items.tpa
@@ -148,7 +148,7 @@ DEFINE_ACTION_FUNCTION item_post_processing STR_VAR table = "" BEGIN
 
                     PATCH_IF NOT ("%exclusion%" STRING_EQUAL_CASE "*") BEGIN
                         //Compute destination.
-                        LPF get_table_ref STR_VAR
+                        LPF expand_table_reference STR_VAR
                             ref = "%destination%"
                         RET destination = resource END
 
@@ -186,7 +186,7 @@ DEFINE_ACTION_FUNCTION item_post_processing STR_VAR table = "" BEGIN
                     TEXT_SPRINT ability3 $"row"("ability3")
 
                     //Compute destination.
-                    LPF get_table_ref STR_VAR
+                    LPF expand_table_reference STR_VAR
                         ref = "%destination%"
                     RET destination = resource END
 

--- a/weidu_library/internal/installers/items.tpa
+++ b/weidu_library/internal/installers/items.tpa
@@ -148,7 +148,7 @@ DEFINE_ACTION_FUNCTION item_post_processing STR_VAR table = "" BEGIN
 
                     PATCH_IF NOT ("%exclusion%" STRING_EQUAL_CASE "*") BEGIN
                         //Compute destination.
-                        LPF get_resource_ref STR_VAR
+                        LPF get_table_ref STR_VAR
                             ref = "%destination%"
                         RET destination = resource END
 
@@ -186,7 +186,7 @@ DEFINE_ACTION_FUNCTION item_post_processing STR_VAR table = "" BEGIN
                     TEXT_SPRINT ability3 $"row"("ability3")
 
                     //Compute destination.
-                    LPF get_resource_ref STR_VAR
+                    LPF get_table_ref STR_VAR
                         ref = "%destination%"
                     RET destination = resource END
 

--- a/weidu_library/internal/installers/scripts.tpa
+++ b/weidu_library/internal/installers/scripts.tpa
@@ -6,21 +6,25 @@ INCLUDE "%WEIDU_LIBRARY_DIR%/components.tpa"
 DEFINE_ACTION_FUNCTION compile_script STR_VAR
     resource = ""
     dir = ""
-    destination = "*"
+    destination = ""
     ext = "*"
     patch = "*"
     fields = "*"
 BEGIN
     //Source and destination.
-    OUTER_TEXT_SPRINT source "%dir%/%resource%.baf"
+    OUTER_TEXT_SPRINT source "%dir%/%resource%"
 
     //Existence checks.
-    ACTION_IF NOT (FILE_EXISTS "%source%") BEGIN
-        FAIL "compile_script: source '%source%' of resource '%resource%' does not exist."
+    ACTION_IF NOT (FILE_EXISTS "%source%.baf") BEGIN
+        FAIL "compile_script: source '%source%.baf' of resource '%resource%' does not exist."
     END
 
+    //Have to first copy the script because COMPILE does not allow renaming.
+    OUTER_TEXT_SPRINT temp "weidu_external/%TP2_BASE_NAME%/%COMPONENT%/resources/baf"
+    COPY "%source%.baf" "%temp%/%destination%.baf"
+
     //Compile script.
-    COMPILE "%source%"
+    COMPILE "%temp%/%destination%.baf"
         PATCH_IF NOT ("%patch%" STRING_EQUAL_CASE "*") BEGIN
             LPF "%patch%" STR_VAR
                 destination = "%destination%"

--- a/weidu_library/references.tpa
+++ b/weidu_library/references.tpa
@@ -31,15 +31,80 @@ DEFINE_DIMORPHIC_FUNCTION replace_affixes STR_VAR spell = "" prefix = "" suffix 
     ACTION_TO_LOWER resource
 END
 
+
+//Main function.
+DEFINE_DIMORPHIC_FUNCTION get_table_ref STR_VAR ref = "" RET resource BEGIN
+    //Available formats.
+    ACTION_DEFINE_ASSOCIATIVE_ARRAY encoders BEGIN
+        "lit" => "encode_resource_literal"
+        "int" => "encode_int_literal"
+        "nul" => "encode_empty_string"
+        "spl" => "encode_spell_res"
+        "suf" => "encode_spell_suffix"
+        "afx" => "encode_spell_affix"
+        "lbl" => "encode_missile_res"
+        "sct" => "encode_spell_sectype"
+        "opc" => "encode_opcode_type"
+    END
+
+    OUTER_TEXT_SPRINT regexp "^#\([a-zA-Z0-9][a-zA-Z0-9_-]*\):\(.*\)$"
+    //Sanitize.
+    ACTION_IF NOT (("%ref%" STRING_MATCHES_REGEXP "%regexp%") = 0) THEN BEGIN
+        FAIL "get_table_ref: string '%ref%' does not have the format of a resource reference."
+    END
+
+    //Parse.
+    OUTER_PATCH "%ref%" BEGIN
+        REPLACE_EVALUATE "%regexp%" BEGIN
+            TEXT_SPRINT name "%MATCH1%"
+            TEXT_SPRINT argument "%MATCH2%"
+        END ~~
+    END
+
+    //Get encoder's name.
+    LAF get_array_element STR_VAR
+        array = "encoders"
+        key = "%name%"
+    RET encoder = value END
+
+    ACTION_IF ("%encoder%" STRING_EQUAL_CASE "*") BEGIN
+        FAIL "get_table_ref: unknown prefix '%name%' in '%ref%' for a resource converter."
+    END
+
+    LAF "%encoder%" STR_VAR value = "%argument%" RET resource = return END
+END
+
+DEFINE_DIMORPHIC_FUNCTION encode_table_ref STR_VAR value = "" RET return BEGIN
+    LAF get_table_ref STR_VAR ref = "%value%" RET return = resource END
+END
+
+
 //Formats.
-DEFINE_DIMORPHIC_FUNCTION encode_ref_literal STR_VAR value = "" RET return BEGIN
+DEFINE_DIMORPHIC_FUNCTION encode_resource_literal STR_VAR value = "" RET return BEGIN
     OUTER_TEXT_SPRINT return "%value%"
 
     //Normalize and sanitize.
-    ACTION_TO_LOWER return
+    ACTION_TO_UPPER return
     ACTION_IF NOT ((STRING_LENGTH "%return%") <= 8) BEGIN
-        FAIL "encode_ref_literal: '%return%' is more than 8 characters long."
+        FAIL "encode_resource_literal: '%return%' is more than 8 characters long."
     END
+END
+
+DEFINE_DIMORPHIC_FUNCTION encode_int_literal STR_VAR value = "" RET return BEGIN
+    ACTION_IF NOT (IS_AN_INT value) BEGIN
+        FAIL "encode_int_literal: value '%value%' is not an integer literal."
+    END
+
+    //Implicit number conversion.
+    OUTER_SET return = value
+END
+
+DEFINE_DIMORPHIC_FUNCTION encode_empty_string STR_VAR value = "" RET return BEGIN
+    ACTION_IF NOT (0 = STRING_LENGTH value) BEGIN
+        FAIL "encode_empty_string: value '%value%' is not the null string."
+    END
+
+    OUTER_TEXT_SPRINT return ""
 END
 
 DEFINE_DIMORPHIC_FUNCTION encode_spell_suffix STR_VAR value = "" RET return BEGIN
@@ -91,54 +156,8 @@ DEFINE_DIMORPHIC_FUNCTION encode_spell_affix STR_VAR value = "" RET return BEGIN
     RET return = resource END
 END
 
-
-//Main function.
-DEFINE_DIMORPHIC_FUNCTION get_resource_ref STR_VAR ref = "" RET resource BEGIN
-    //Available formats.
-    ACTION_DEFINE_ASSOCIATIVE_ARRAY encoders BEGIN
-        "lit" => "encode_ref_literal"
-        "spl" => "encode_spell_res"
-        "lbl" => "encode_missile_res"
-        "suf" => "encode_spell_suffix"
-        "afx" => "encode_spell_affix"
-        "opc" => "encode_opcode_type"
-        "sct" => "encode_spell_sectype"
-    END
-
-    OUTER_TEXT_SPRINT regexp "^#\([a-zA-Z0-9][a-zA-Z0-9_-]*\):\(.+\)$"
-    //Sanitize.
-    ACTION_IF NOT (("%ref%" STRING_MATCHES_REGEXP "%regexp%") = 0) THEN BEGIN
-        FAIL "get_resource_ref: string '%ref%' does not have the format of a resource reference."
-    END
-
-    //Parse.
-    OUTER_PATCH "%ref%" BEGIN
-        REPLACE_EVALUATE "%regexp%" BEGIN
-            TEXT_SPRINT name "%MATCH1%"
-            TEXT_SPRINT argument "%MATCH2%"
-        END ~~
-    END
-
-    //Get encoder's name.
-    LAF get_array_element STR_VAR
-        array = "encoders"
-        key = "%name%"
-    RET encoder = value END
-
-    ACTION_IF ("%encoder%" STRING_EQUAL_CASE "*") BEGIN
-        FAIL "get_resource_ref: unknown prefix '%name%' in '%ref%' for a resource converter."
-    END
-
-    LAF "%encoder%" STR_VAR value = "%argument%" RET resource = return END
-END
-
-//Encoders.
-DEFINE_DIMORPHIC_FUNCTION encode_resource_ref STR_VAR value = "" RET return BEGIN
-    LAF get_resource_ref STR_VAR ref = "%value%" RET return = resource END
-END
-
 DEFINE_DIMORPHIC_FUNCTION encode_bam_ref STR_VAR value = "" RET return BEGIN
-    LAF get_resource_ref STR_VAR ref = "%value%" RET return = resource END
+    LAF get_table_ref STR_VAR ref = "%value%" RET return = resource END
 
     //Sanitize.
     ACTION_IF NOT (FILE_EXISTS_IN_GAME "%return%.bam") BEGIN
@@ -147,7 +166,7 @@ DEFINE_DIMORPHIC_FUNCTION encode_bam_ref STR_VAR value = "" RET return BEGIN
 END
 
 DEFINE_DIMORPHIC_FUNCTION encode_projectile_ref STR_VAR value = "" RET return BEGIN
-    LAF encode_resource_ref STR_VAR
+    LAF encode_table_ref STR_VAR
         value = "%value%"
     RET resource = return END
     
@@ -161,7 +180,7 @@ DEFINE_DIMORPHIC_FUNCTION encode_projectile_ref STR_VAR value = "" RET return BE
 END
 
 DEFINE_DIMORPHIC_FUNCTION encode_script_ref STR_VAR value = "" RET return BEGIN
-    LAF get_resource_ref STR_VAR ref = "%value%" RET return = resource END
+    LAF get_table_ref STR_VAR ref = "%value%" RET return = resource END
 
     //Sanitize.
     ACTION_IF NOT (FILE_EXISTS_IN_GAME "%return%.bcs") BEGIN

--- a/weidu_library/references.tpa
+++ b/weidu_library/references.tpa
@@ -33,7 +33,7 @@ END
 
 
 //Main function.
-DEFINE_DIMORPHIC_FUNCTION expand_table_reference STR_VAR ref = "" RET resource BEGIN
+DEFINE_DIMORPHIC_FUNCTION encode_table_reference STR_VAR value = "" RET return BEGIN
     //Available formats.
     ACTION_DEFINE_ASSOCIATIVE_ARRAY encoders BEGIN
         "lit" => "encode_resource_literal"
@@ -49,12 +49,12 @@ DEFINE_DIMORPHIC_FUNCTION expand_table_reference STR_VAR ref = "" RET resource B
 
     OUTER_TEXT_SPRINT regexp "^#\([a-zA-Z0-9][a-zA-Z0-9_-]*\):\(.*\)$"
     //Sanitize.
-    ACTION_IF NOT (("%ref%" STRING_MATCHES_REGEXP "%regexp%") = 0) THEN BEGIN
-        FAIL "expand_table_reference: string '%ref%' does not have the format of a resource reference."
+    ACTION_IF NOT (("%value%" STRING_MATCHES_REGEXP "%regexp%") = 0) THEN BEGIN
+        FAIL "encode_table_reference: string '%value%' does not have the format of a table reference."
     END
 
     //Parse.
-    OUTER_PATCH "%ref%" BEGIN
+    OUTER_PATCH "%value%" BEGIN
         REPLACE_EVALUATE "%regexp%" BEGIN
             TEXT_SPRINT name "%MATCH1%"
             TEXT_SPRINT argument "%MATCH2%"
@@ -68,16 +68,11 @@ DEFINE_DIMORPHIC_FUNCTION expand_table_reference STR_VAR ref = "" RET resource B
     RET encoder = value END
 
     ACTION_IF ("%encoder%" STRING_EQUAL_CASE "*") BEGIN
-        FAIL "expand_table_reference: unknown prefix '%name%' in '%ref%' for a resource converter."
+        FAIL "encode_table_reference: unknown prefix '%name%' in '%value%' for encoder."
     END
 
-    LAF "%encoder%" STR_VAR value = "%argument%" RET resource = return END
+    LAF "%encoder%" STR_VAR value = "%argument%" RET return END
 END
-
-DEFINE_DIMORPHIC_FUNCTION encode_table_reference STR_VAR value = "" RET return BEGIN
-    LAF expand_table_reference STR_VAR ref = "%value%" RET return = resource END
-END
-
 
 //Formats.
 DEFINE_DIMORPHIC_FUNCTION encode_resource_literal STR_VAR value = "" RET return BEGIN
@@ -157,7 +152,7 @@ DEFINE_DIMORPHIC_FUNCTION encode_spell_affix STR_VAR value = "" RET return BEGIN
 END
 
 DEFINE_DIMORPHIC_FUNCTION encode_bam_ref STR_VAR value = "" RET return BEGIN
-    LAF expand_table_reference STR_VAR ref = "%value%" RET return = resource END
+    LAF encode_table_reference STR_VAR value = "%value%" RET return END
 
     //Sanitize.
     ACTION_IF NOT (FILE_EXISTS_IN_GAME "%return%.bam") BEGIN
@@ -180,7 +175,7 @@ DEFINE_DIMORPHIC_FUNCTION encode_projectile_ref STR_VAR value = "" RET return BE
 END
 
 DEFINE_DIMORPHIC_FUNCTION encode_script_ref STR_VAR value = "" RET return BEGIN
-    LAF expand_table_reference STR_VAR ref = "%value%" RET return = resource END
+    LAF encode_table_reference STR_VAR value = "%value%" RET return END
 
     //Sanitize.
     ACTION_IF NOT (FILE_EXISTS_IN_GAME "%return%.bcs") BEGIN

--- a/weidu_library/references.tpa
+++ b/weidu_library/references.tpa
@@ -33,7 +33,7 @@ END
 
 
 //Main function.
-DEFINE_DIMORPHIC_FUNCTION get_table_ref STR_VAR ref = "" RET resource BEGIN
+DEFINE_DIMORPHIC_FUNCTION expand_table_reference STR_VAR ref = "" RET resource BEGIN
     //Available formats.
     ACTION_DEFINE_ASSOCIATIVE_ARRAY encoders BEGIN
         "lit" => "encode_resource_literal"
@@ -50,7 +50,7 @@ DEFINE_DIMORPHIC_FUNCTION get_table_ref STR_VAR ref = "" RET resource BEGIN
     OUTER_TEXT_SPRINT regexp "^#\([a-zA-Z0-9][a-zA-Z0-9_-]*\):\(.*\)$"
     //Sanitize.
     ACTION_IF NOT (("%ref%" STRING_MATCHES_REGEXP "%regexp%") = 0) THEN BEGIN
-        FAIL "get_table_ref: string '%ref%' does not have the format of a resource reference."
+        FAIL "expand_table_reference: string '%ref%' does not have the format of a resource reference."
     END
 
     //Parse.
@@ -68,14 +68,14 @@ DEFINE_DIMORPHIC_FUNCTION get_table_ref STR_VAR ref = "" RET resource BEGIN
     RET encoder = value END
 
     ACTION_IF ("%encoder%" STRING_EQUAL_CASE "*") BEGIN
-        FAIL "get_table_ref: unknown prefix '%name%' in '%ref%' for a resource converter."
+        FAIL "expand_table_reference: unknown prefix '%name%' in '%ref%' for a resource converter."
     END
 
     LAF "%encoder%" STR_VAR value = "%argument%" RET resource = return END
 END
 
-DEFINE_DIMORPHIC_FUNCTION encode_table_ref STR_VAR value = "" RET return BEGIN
-    LAF get_table_ref STR_VAR ref = "%value%" RET return = resource END
+DEFINE_DIMORPHIC_FUNCTION encode_table_reference STR_VAR value = "" RET return BEGIN
+    LAF expand_table_reference STR_VAR ref = "%value%" RET return = resource END
 END
 
 
@@ -157,7 +157,7 @@ DEFINE_DIMORPHIC_FUNCTION encode_spell_affix STR_VAR value = "" RET return BEGIN
 END
 
 DEFINE_DIMORPHIC_FUNCTION encode_bam_ref STR_VAR value = "" RET return BEGIN
-    LAF get_table_ref STR_VAR ref = "%value%" RET return = resource END
+    LAF expand_table_reference STR_VAR ref = "%value%" RET return = resource END
 
     //Sanitize.
     ACTION_IF NOT (FILE_EXISTS_IN_GAME "%return%.bam") BEGIN
@@ -166,7 +166,7 @@ DEFINE_DIMORPHIC_FUNCTION encode_bam_ref STR_VAR value = "" RET return BEGIN
 END
 
 DEFINE_DIMORPHIC_FUNCTION encode_projectile_ref STR_VAR value = "" RET return BEGIN
-    LAF encode_table_ref STR_VAR
+    LAF encode_table_reference STR_VAR
         value = "%value%"
     RET resource = return END
     
@@ -180,7 +180,7 @@ DEFINE_DIMORPHIC_FUNCTION encode_projectile_ref STR_VAR value = "" RET return BE
 END
 
 DEFINE_DIMORPHIC_FUNCTION encode_script_ref STR_VAR value = "" RET return BEGIN
-    LAF get_table_ref STR_VAR ref = "%value%" RET return = resource END
+    LAF expand_table_reference STR_VAR ref = "%value%" RET return = resource END
 
     //Sanitize.
     ACTION_IF NOT (FILE_EXISTS_IN_GAME "%return%.bcs") BEGIN

--- a/weidu_library/subspells.tpa
+++ b/weidu_library/subspells.tpa
@@ -63,9 +63,9 @@ BEGIN
 
                 ACTION_IF NOT (install = 0) BEGIN
                     //Compute destination.
-                    LAF expand_table_reference STR_VAR
-                        ref = "%destination%"
-                    RET destination = resource END
+                    LAF encode_table_reference STR_VAR
+                        value = "%destination%"
+                    RET destination = return END
 
                     //Override checks.
                     //Sanitize override.

--- a/weidu_library/subspells.tpa
+++ b/weidu_library/subspells.tpa
@@ -63,7 +63,7 @@ BEGIN
 
                 ACTION_IF NOT (install = 0) BEGIN
                     //Compute destination.
-                    LAF get_resource_ref STR_VAR
+                    LAF get_table_ref STR_VAR
                         ref = "%destination%"
                     RET destination = resource END
 

--- a/weidu_library/subspells.tpa
+++ b/weidu_library/subspells.tpa
@@ -73,16 +73,20 @@ BEGIN
                         FAIL "install_subspells: '%override%' is not an integer."
                     END
 
-                    ACTION_IF NOT ((0 <= override) AND (override <= 2)) BEGIN
-                        FAIL "install_subspells: '%override%' not an integer in the [0, 2] range."
+                    ACTION_IF NOT ((0 <= override) AND (override <= 3)) BEGIN
+                        FAIL "install_subspells: '%override%' not an integer in the [0, 3] range."
                     END
 
                     ACTION_IF (0 = override) AND (FILE_EXISTS_IN_GAME "%destination%.spl") BEGIN
                         FAIL "install_subspells: destination '%destination%.spl' for '%resource%' already exists in game."
                     END
 
-                    ACTION_IF (2 = override) AND (NOT (FILE_EXISTS_IN_GAME "%destination%.%ext%")) BEGIN
-                        FAIL "install_subspells: destination '%destination%.spl' for '%resource%' declared to exist but does not."
+                    ACTION_IF (2 = override) AND (FILE_EXISTS_IN_GAME "%destination%.%ext%") BEGIN
+                        WARN "install_subspells: destination '%destination%.%ext%' for '%resource%' already exists in game."
+                    END
+
+                    ACTION_IF (3 = override) AND (NOT (FILE_EXISTS_IN_GAME "%destination%.%ext%")) BEGIN
+                        FAIL "install_subspells: destination '%destination%.%ext%' for '%resource%' declared to exist but does not."
                     END
 
                     //Process record.

--- a/weidu_library/subspells.tpa
+++ b/weidu_library/subspells.tpa
@@ -63,7 +63,7 @@ BEGIN
 
                 ACTION_IF NOT (install = 0) BEGIN
                     //Compute destination.
-                    LAF get_table_ref STR_VAR
+                    LAF expand_table_reference STR_VAR
                         ref = "%destination%"
                     RET destination = resource END
 


### PR DESCRIPTION
Patch doing three unrelated things (as needed, or prompted, by spell_revisions):

1. Add a fourth override mode to issue only a warning on override.
2. Fix renaming issues in the script installer.
3. Refactor the references table to more properly reflect its actual usage as just more than managing resource references but as a tiny dsl to inline values in tables.